### PR TITLE
Preserve the value of OTEL_RESOURCE_ATTRIBUTES, if any.

### DIFF
--- a/common/src/main/java/com/lightstep/opentelemetry/common/VariablesConverter.java
+++ b/common/src/main/java/com/lightstep/opentelemetry/common/VariablesConverter.java
@@ -19,6 +19,7 @@ public class VariablesConverter {
   static final String OTEL_PROPAGATORS = "OTEL_PROPAGATORS";
   static final String OTEL_EXPORTER_OTLP_SPAN_INSECURE = "OTEL_EXPORTER_OTLP_SPAN_INSECURE";
   static final String OTEL_LOG_LEVEL = "OTEL_LOG_LEVEL";
+  static final String OTEL_RESOURCE_ATTRIBUTES = "OTEL_RESOURCE_ATTRIBUTES";
 
   public static void setSystemProperties(String spanEndpoint,
       boolean insecureTransport,
@@ -75,6 +76,11 @@ public class VariablesConverter {
     if (serviceVersion != null) {
       otelResourceAttributes += ",service.version=" + serviceVersion;
     }
+    String envResourceAttributes = getResourceAttributes();
+    if (envResourceAttributes != null && !envResourceAttributes.isEmpty()) {
+      // Keep the existing env Resource attributes, if any.
+      otelResourceAttributes += "," + envResourceAttributes;
+    }
     System.setProperty("otel.resource.attributes", otelResourceAttributes);
   }
 
@@ -120,6 +126,11 @@ public class VariablesConverter {
   public static boolean useInsecureTransport() {
     return Boolean.parseBoolean(getProperty(OTEL_EXPORTER_OTLP_SPAN_INSECURE, String.valueOf(
         DEFAULT_OTEL_EXPORTER_OTLP_SPAN_INSECURE)));
+  }
+
+  // Internal usage, do not need to expose publicly.
+  static String getResourceAttributes() {
+    return getProperty(OTEL_RESOURCE_ATTRIBUTES, null);
   }
 
   private static String getProperty(String name, String defaultValue) {

--- a/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
+++ b/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
@@ -190,6 +190,24 @@ public class VariablesConverterTest {
     assertTrue(VariablesConverter.useInsecureTransport());
   }
 
+  @Test
+  public void getResourceAttributes_Default() {
+    assertEquals(null, VariablesConverter.getResourceAttributes());
+  }
+
+  @Test
+  public void getResourceAttributes_fromSystemProperty() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_RESOURCE_ATTRIBUTES), "key1=value1");
+    assertEquals("key1=value1", VariablesConverter.getResourceAttributes());
+  }
+
+  @Test
+  public void getResourceAttributes_fromEnvVariable() {
+    mockSystem();
+    Mockito.when(System.getenv(VariablesConverter.OTEL_RESOURCE_ATTRIBUTES)).thenReturn("key1=value1");
+    assertEquals("key1=value1", VariablesConverter.getResourceAttributes());
+  }
+
   private void mockSystem() {
     PowerMockito.mockStatic(System.class);
     Mockito.when(System.getProperty(anyString(), anyString())).thenAnswer(


### PR DESCRIPTION
Please review @malafeev 

PS - I added basic tests, but couldn't find a test for `setSystemProperties()`- I'd like to verify that I'm *not* ignoring the existing `OTEL_RESOURCE_ATTRIBUTES`. Maybe we can do that in a follow up?