### PR TITLE
Use the correct method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ OpenTelemetryConfiguration.newBuilder()
                       .install();
 
 // Get tracer
-Tracer tracer = OpenTelemetry.getGlobalTracer("instrumentation-library-name", "1.0.0");
+Tracer tracer = GlobalOpenTelemetry.getTracer("instrumentation-library-name", "1.0.0");
 ```
 
 #### Manual configuration


### PR DESCRIPTION
OpenTelemetry interface does not have a static method named as `getGlobalTracer `.  `GlobalOpenTelemetry` has a static method named `getTracer`. This is what I can find closest to the original code.