### PR TITLE
Enable metrics as an experimental feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ Supported system properties and environmental variables:
 | ls.service.version                 | LS_SERVICE_VERSION                 | Service version                                                                   |                      |                        
 | ls.access.token                    | LS_ACCESS_TOKEN                    | Token for Lightstep access                                                        |                      |                        
 | otel.exporter.otlp.traces.endpoint | OTEL_EXPORTER_OTLP_TRACES_ENDPOINT | Satellite URL, should start with _http://_ or _https://_                          | https://ingest.lightstep.com:443 |
+| otel.exporter.otlp.metrics.endpoint| OTEL_EXPORTER_OTLP_METRICS_ENDPOINT| Satellite URL, should start with _http://_ or _https://_                          | https://ingest.lightstep.com:443 |
 | otel.propagators                   | OTEL_PROPAGATORS                   | Propagator                                                                        | b3multi              |
 | otel.log.level                     | OTEL_LOG_LEVEL                     | Log level for agent, to see more messages set to _debug_, to disable set to _off_ | info                 |
 | otel.resource.attributes           | OTEL_RESOURCE_ATTRIBUTES           | Comma separated key-value pairs                                                   |                      |
+| otel.exporter.otlp.metrics.temporality.preference | OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | Metrics aggregation temporality                     | cumulative           |
+| ls.metrics.enabled                 | LS_METRICS_ENABLED                 | Enable or disable metrics                                                         | false                |
 
 ## Deprecated properties and environmental variables
 

--- a/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
+++ b/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
@@ -27,11 +27,14 @@ public class VariablesConverterTest {
     System.clearProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN));
     System.clearProperty(toSystemProperty(VariablesConverter.LS_SERVICE_NAME));
     System.clearProperty(toSystemProperty(VariablesConverter.LS_SERVICE_VERSION));
+    System.clearProperty(toSystemProperty(VariablesConverter.LS_METRICS_ENABLED));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_LOG_LEVEL));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_SPAN_ENDPOINT));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT));
+    System.clearProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_SPAN_INSECURE));
+    System.clearProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRIC_INSECURE));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_PROPAGATORS));
     System.clearProperty(toSystemProperty(VariablesConverter.OTEL_RESOURCE_ATTRIBUTES));
   }
@@ -75,6 +78,31 @@ public class VariablesConverterTest {
   }
 
   @Test
+  public void convertFromEnv_withtMetricsDisabled() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME), "service-1");
+    System.setProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN),
+        StringUtils.repeat("s", 32));
+    System.setProperty(toSystemProperty(VariablesConverter.LS_METRICS_ENABLED), "false");
+
+    VariablesConverter.convertFromEnv();
+
+    assertNull(System.getProperty("otel.exporter.otlp.metrics.endpoint"));
+  }
+
+  @Test
+  public void convertFromEnv_withMetricsEnabled() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME), "service-1");
+    System.setProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN),
+        StringUtils.repeat("s", 32));
+    System.setProperty(toSystemProperty(VariablesConverter.LS_METRICS_ENABLED), "true");
+
+    VariablesConverter.convertFromEnv();
+
+    assertEquals(VariablesConverter.DEFAULT_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, System
+        .getProperty("otel.exporter.otlp.metrics.endpoint"));
+  }
+
+  @Test
   public void convertFromEnv_InsecureFalse() {
     System.setProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME), "service-1");
     System.setProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN),
@@ -102,6 +130,38 @@ public class VariablesConverterTest {
     VariablesConverter.convertFromEnv();
 
     assertEquals("http://endpoint", System.getProperty("otel.exporter.otlp.traces.endpoint"));
+  }
+
+  @Test
+  public void convertFromEnv_InsecureMetricFalse() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME), "service-1");
+    System.setProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN),
+        StringUtils.repeat("s", 32));
+    System.setProperty(toSystemProperty(VariablesConverter.LS_METRICS_ENABLED), "true");
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+        "endpoint");
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRIC_INSECURE),
+        "false");
+
+    VariablesConverter.convertFromEnv();
+
+    assertEquals("https://endpoint", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
+  }
+
+  @Test
+  public void convertFromEnv_InsecureMetricTrue() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_SERVICE_NAME), "service-1");
+    System.setProperty(toSystemProperty(VariablesConverter.LS_ACCESS_TOKEN),
+        StringUtils.repeat("s", 32));
+    System.setProperty(toSystemProperty(VariablesConverter.LS_METRICS_ENABLED), "true");
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+        "endpoint");
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRIC_INSECURE),
+        "true");
+
+    VariablesConverter.convertFromEnv();
+
+    assertEquals("http://endpoint", System.getProperty("otel.exporter.otlp.metrics.endpoint"));
   }
 
   @Test
@@ -223,6 +283,27 @@ public class VariablesConverterTest {
   }
 
   @Test
+  public void getMetricsEndpoint_Default() {
+    assertEquals(VariablesConverter.DEFAULT_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+        VariablesConverter.getMetricsEndpoint());
+  }
+
+  @Test
+  public void getMetricsEndpoint_fromSystemProperty() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+        "endpoint-prop");
+    assertEquals("endpoint-prop", VariablesConverter.getMetricsEndpoint());
+  }
+
+  @Test
+  public void getMetricsEndpoint_fromEnvVariable() {
+    mockSystem();
+    Mockito.when(System.getenv(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT))
+        .thenReturn("endpoint-env");
+    assertEquals("endpoint-env", VariablesConverter.getMetricsEndpoint());
+  }
+
+  @Test
   public void getPropagator_Default() {
     assertEquals(VariablesConverter.DEFAULT_PROPAGATOR,
         VariablesConverter.getPropagator());
@@ -268,6 +349,12 @@ public class VariablesConverterTest {
     final String hostName = VariablesConverter.getHostName();
     assertNotNull(hostName);
     assertFalse(hostName.isEmpty());
+  }
+
+  // Make sure metrics is enabled till we *officially* support it.
+  @Test
+  public void getMetricsEnabled() {
+    assertFalse(VariablesConverter.getMetricsEnabled());
   }
 
   private void mockSystem() {

--- a/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
+++ b/common/src/test/java/com/lightstep/opentelemetry/common/VariablesConverterTest.java
@@ -357,6 +357,26 @@ public class VariablesConverterTest {
     assertFalse(VariablesConverter.getMetricsEnabled());
   }
 
+  @Test
+  public void getMetricsTemporality_Default() {
+    assertNull(VariablesConverter.getMetricsTemporalityPreference());
+  }
+
+  @Test
+  public void getMetricsTemporality_fromSystemProperty() {
+    System.setProperty(toSystemProperty(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE),
+        "delta");
+    assertEquals("delta", VariablesConverter.getMetricsTemporalityPreference());
+  }
+
+  @Test
+  public void getMetricsTemporality_fromEnvVariable() {
+    mockSystem();
+    Mockito.when(System.getenv(VariablesConverter.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE))
+        .thenReturn("cumulative");
+    assertEquals("cumulative", VariablesConverter.getMetricsTemporalityPreference());
+  }
+
   private void mockSystem() {
     PowerMockito.mockStatic(System.class);
     Mockito.when(System.getProperty(anyString(), anyString())).thenAnswer(

--- a/launcher/src/main/java/com/lightstep/opentelemetry/launcher/OpenTelemetryConfiguration.java
+++ b/launcher/src/main/java/com/lightstep/opentelemetry/launcher/OpenTelemetryConfiguration.java
@@ -17,9 +17,11 @@ public class OpenTelemetryConfiguration {
     private String serviceName;
     private String serviceVersion;
     private String tracesEndpoint;
+    private String metricsEndpoint;
     private String resourceAttributes;
     @Deprecated
-    private boolean insecureTransport;
+    private boolean tracesInsecureTransport;
+    private boolean metricsInsecureTransport;
     private final List<Propagator> propagators = new ArrayList<>();
 
 
@@ -69,7 +71,7 @@ public class OpenTelemetryConfiguration {
      */
     @Deprecated
     public Builder useInsecureTransport(boolean insecureTransport) {
-      this.insecureTransport = insecureTransport;
+      this.tracesInsecureTransport = insecureTransport;
       return this;
     }
 
@@ -95,7 +97,9 @@ public class OpenTelemetryConfiguration {
       VariablesConverter
           .setSystemProperties(new Configuration()
               .withTracesEndpoint(tracesEndpoint)
-              .withInsecureTransport(insecureTransport)
+              .withTracesInsecureTransport(tracesInsecureTransport)
+              .withMetricsEndpoint(metricsEndpoint)
+              .withMetricsInsecureTransport(metricsInsecureTransport)
               .withAccessToken(accessToken)
               .withServiceName(serviceName)
               .withServiceVersion(serviceVersion)
@@ -118,8 +122,10 @@ public class OpenTelemetryConfiguration {
       this.serviceName = VariablesConverter.getServiceName();
       this.serviceVersion = VariablesConverter.getServiceVersion();
       this.tracesEndpoint = VariablesConverter.getTracesEndpoint();
+      this.metricsEndpoint = VariablesConverter.getMetricsEndpoint();
       this.resourceAttributes = VariablesConverter.getResourceAttributes();
-      this.insecureTransport = VariablesConverter.useInsecureTransport();
+      this.tracesInsecureTransport = VariablesConverter.useTracesInsecureTransport();
+      this.metricsInsecureTransport = VariablesConverter.useMetricsInsecureTransport();
     }
 
     List<Propagator> getPropagators() {


### PR DESCRIPTION
Enable metrics as an experimental feature.

* Document the LS_METRICS_ENABLED configuration option.
* Handle metrics endpoint/insecure (backwards compatibility included).
* Update interval env var.
* Enable Exponential Histogram aggregation by default (overriding the Explicit
aggregation).