### PR TITLE
Remove our grpc dependency for the non-agent part.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <a name="Pending Release"></a>
 ## [Pending Release](https://github.com/lightstep/otel-launcher-java/compare/1.19.0...main)
+* Remove our grpc dependency for launcher/
 
 <a name="1.19.0"></a>
 ## [1.19.0](https://github.com/lightstep/otel-launcher-java/compare/1.17.0...1.19.0)

--- a/examples/launcher/pom.xml
+++ b/examples/launcher/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.lightstep.opentelemetry</groupId>
       <artifactId>opentelemetry-launcher</artifactId>
-      <version>1.5.0</version>
+      <version>1.19.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/launcher/src/main/java/com/lightstep/opentelemetry/launcher/example/Main.java
+++ b/examples/launcher/src/main/java/com/lightstep/opentelemetry/launcher/example/Main.java
@@ -18,7 +18,7 @@ public class Main {
         .setServiceName(properties.getProperty("otel.service.name"))
         .setAccessToken(properties.getProperty("ls.access.token"))
         .setTracesEndpoint(properties.getProperty("otel.exporter.otlp.traces.endpoint"))
-        .buildOpenTelemetry();
+        .buildOpenTelemetry().getOpenTelemetrySdk();
 
     Tracer tracer = openTelemetry.getTracer("LightstepExample");
     Span span = tracer.spanBuilder("start example").setSpanKind(SpanKind.CLIENT).startSpan();

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -39,17 +39,11 @@
     </dependency>
 
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-      <version>1.36.1</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+      <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.38.Final</version>
-    </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
gRPC has been long removed as a dependency for the standard OTLP exporter, hence we don't need to
explicitly bring it in.

Add a dependency to Guava as we used that in the tests and it automatically came with the grpc deps.